### PR TITLE
Fix "request entity too large" Error on Large File Upload

### DIFF
--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -9,12 +9,13 @@ import User from '#models/user'
 import encryption from '@adonisjs/core/services/encryption'
 import crypto from 'node:crypto'
 import vine, { SimpleMessagesProvider } from '@vinejs/vine'
-import app from '@adonisjs/core/services/app'
-import { allowedExtensions, allowedPattern } from '../../helpers/file_upload_helper.js'
+import {
+  allowedExtensions,
+  allowedPattern,
+  maxFileSizeMB,
+} from '../../helpers/file_upload_helper.js'
 
 const stringRules = [rules.trim(), rules.escape()]
-
-const maxFileSizeMB = app.inTest ? 50 : 500 // in "mb"
 
 export default class FileUploadsController {
   public async store({ request, response }: HttpContext) {
@@ -39,7 +40,7 @@ export default class FileUploadsController {
         'file_name.required': 'Original file name is required.',
         'file_name.regex': `Invalid file type. Only ${allowedExtensions.join(', ')} are allowed.`,
         'file_size.required': 'File size is required',
-        'file_size.range': 'File size must not exceed 500mb.',
+        'file_size.range': `File size must not exceed ${maxFileSizeMB}mb.`,
       },
     })
 

--- a/config/bodyparser.ts
+++ b/config/bodyparser.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@adonisjs/core/bodyparser'
+import { maxFileSizeMB } from '../helpers/file_upload_helper.js'
 
 const bodyParserConfig = defineConfig({
   /**
@@ -47,7 +48,7 @@ const bodyParserConfig = defineConfig({
      * Maximum limit of data to parse including all files
      * and fields
      */
-    limit: '20mb',
+    limit: `${maxFileSizeMB}mb`,
     types: ['multipart/form-data'],
   },
 })

--- a/helpers/file_upload_helper.ts
+++ b/helpers/file_upload_helper.ts
@@ -1,3 +1,7 @@
+import app from '@adonisjs/core/services/app'
+
 export const allowedExtensions = ['zip', 'doc', 'docx', 'pdf']
 
 export const allowedPattern = new RegExp(`\\.(${allowedExtensions.join('|')})$`, 'i')
+
+export const maxFileSizeMB = app.inTest ? 50 : 500 // in "mb"

--- a/tests/functional/upload.spec.ts
+++ b/tests/functional/upload.spec.ts
@@ -10,7 +10,11 @@ import drive from '@adonisjs/drive/services/main'
 import { FileUploadStatuses } from '#models/file_upload'
 import { faker } from '@faker-js/faker'
 import app from '@adonisjs/core/services/app'
-import { allowedExtensions, allowedPattern } from '../../helpers/file_upload_helper.js'
+import {
+  allowedExtensions,
+  allowedPattern,
+  maxFileSizeMB,
+} from '../../helpers/file_upload_helper.js'
 import AdmZip from 'adm-zip'
 import { randomBytes } from 'crypto'
 
@@ -155,7 +159,7 @@ test.group('Upload', (group) => {
       zipFile.addFile(
         'file.txt',
         condition === 'file_size_exceeds_max_size'
-          ? randomBytes(1024 * 1024 * 60)
+          ? randomBytes(1024 * 1024 * (maxFileSizeMB + 10))
           : Buffer.alloc(1024, '0')
       )
 
@@ -205,7 +209,7 @@ test.group('Upload', (group) => {
           break
 
         case 'file_size_exceeds_max_size':
-          message = 'File size must not exceed 500mb.'
+          message = `File size must not exceed ${maxFileSizeMB}mb.`
           break
 
         case 'title_not_provided':
@@ -221,6 +225,45 @@ test.group('Upload', (group) => {
       }
 
       command.assertLog(`[ red(error) ] ${message}`)
+    })
+    .tags(['upload'])
+    .timeout(30000)
+
+  test('should upload a large file that is under the max file size limit')
+    .run(async ({ assert }) => {
+      const email = 'test@example.com'
+
+      const user = await User.create({ email, licence_key: cuid() })
+
+      const title = 'My Important File'
+
+      const zipFile = new AdmZip()
+      zipFile.addFile('file.txt', randomBytes(1024 * 1024 * (maxFileSizeMB - 5)))
+
+      await zipFile.writeZipPromise(testFilePath)
+
+      const command = await ace.create(Upload, [
+        testFilePath,
+        `--email=${email}`,
+        `--title=${title}`,
+      ])
+
+      await command.exec()
+
+      command.assertSucceeded()
+
+      command.assertLog('[ blue(info) ] File upload successful.')
+
+      await user.load('fileUploads')
+
+      const upload = user.fileUploads[0].serialize()
+
+      const disk = drive.use('s3')
+
+      assert.isTrue(await disk.exists(upload.file_data.location))
+
+      // Cleanup
+      await disk.delete(upload.file_data.location)
     })
     .tags(['upload'])
     .timeout(30000)


### PR DESCRIPTION
This PR:

- fixes "request entity too large" error on attempting to upload a large file. This is due to Adonis body parser limit of 20mb
- adds a test to show that large files under the application max file size limit are successfully uploaded