### PR TITLE
Check File Signature (Magic-Bytes) during Upload

### DIFF
--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -102,7 +102,7 @@ export default class FileUploadsController {
 
     // Handle streaming errors
     combinedStream.on('error', (error) => {
-      console.error('Stream Error:', error)
+      logger.error({ error, fileUploadId: fileUpload.id, userId: user.id }, 'Stream Error')
     })
     encryptedStream.on('error', (error) => {
       combinedStream.destroy(error)
@@ -115,7 +115,10 @@ export default class FileUploadsController {
     // Handle user download cancellation
     request.request.on('close', () => {
       if (!isFinished) {
-        console.log('Download cancelled by user or network error.')
+        logger.warn(
+          { fileUploadId: fileUpload.id, userId: user.id },
+          'Download cancelled by user or network error.'
+        )
       }
 
       if (!combinedStream.destroyed) {

--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -71,7 +71,7 @@ export default class FileUploadsController {
     const { user } = validationResult
 
     const fileUpload = await FileUpload.query()
-      .where({ id: params.id })
+      .where({ id: params.id, status: FileUploadStatuses.Completed })
       .whereHas('user', (userQuery) => {
         userQuery.select('id').where({ id: user.id })
       })

--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -17,6 +17,8 @@ import {
 } from '../../helpers/file_upload_helper.js'
 import drive from '@adonisjs/drive/services/main'
 import { PassThrough } from 'node:stream'
+import { fileTypeFromStream } from 'file-type'
+import logger from '@adonisjs/core/services/logger'
 
 const stringRules = [rules.trim(), rules.escape()]
 
@@ -169,6 +171,7 @@ export default class FileUploadsController {
         'title.maxLength': 'Title must not exceed 100 characters.',
         'email.required': 'Email is required.',
         'file_name.required': 'Original file name is required.',
+        // NB: The actual file signature will be checked during streaming to prevent spoofing
         'file_name.regex': `Invalid file type. Only ${allowedExtensions.join(', ')} are allowed.`,
         'file_size.required': 'File size is required',
         'file_size.range': `File size must not exceed ${maxFileSizeMB}mb.`,
@@ -271,6 +274,11 @@ export default class FileUploadsController {
           return
         }
 
+        // Set up a PassThrough "sniffer" to check the actual file signature, without consuming the data meant for the upload to S3
+        const sniffer = new PassThrough()
+
+        part.pipe(sniffer)
+
         const cipher = crypto.createCipheriv('aes-256-gcm', rawFileKey, iv)
 
         part.pause()
@@ -301,11 +309,37 @@ export default class FileUploadsController {
 
         // For debugging
         // upload.on('httpUploadProgress', (progress) => {
-        //   console.log('progress...', progress)
+        //   logger.debug(progress, 'progress...')
         // })
 
-        await upload.done()
+        // CRITICAL Run the file signature check and the upload in parallel.
+        // Do not await the file signature check before starting the upload,
+        // This ensures that data is ALWAYS moving to S3, which prevents deadlock (backpressure) for large files.
+        const checkFileType = async () => {
+          const fileType = await fileTypeFromStream(sniffer)
 
+          // CRITICAL: Once the sniffer has the file header, it stops consuming data. We must resume it (to drain the sniffer) so that the main S3 stream does not back up
+          sniffer.resume()
+
+          if (!fileType || !allowedExtensions.includes(fileType.ext)) {
+            const errorMessage = 'Mime-type spoofing detected!'
+            part.emit('error', new Error(errorMessage))
+
+            logger.warn({ fileType, errorMessage, fileUploadId: fileUpload.id })
+
+            // Force `Promise.all` to reject immediately
+            throw new Error(errorMessage)
+          }
+        }
+
+        try {
+          await Promise.all([checkFileType(), upload.done()])
+        } catch (error) {
+          // Exit the callback safely
+          return
+        }
+
+        // If we reach this point, the file is valid and fully uploaded to S3
         const authTag = cipher.getAuthTag()
 
         fileUpload.merge({
@@ -317,7 +351,7 @@ export default class FileUploadsController {
         })
 
         /**
-         * We adopt the approach above (bypassing Adonis Drive and talking directly to AWS) to avoid "MissingContentLength" error for the stream
+         * We adopt the approach of bypassing Adonis Drive and talking directly to AWS to avoid "MissingContentLength" error for the stream. We don't do this:
          */
         // await drive.use('s3').putStream(`${Date.now()}_${part.file.clientName}_${cuid()}`, part, {
         //   contentLength: part.file.size,
@@ -336,7 +370,7 @@ export default class FileUploadsController {
 
     const errors = file.errors.map((error) => {
       const messages = {
-        extname: `${file.clientName} is not a zip`,
+        extname: `The file content does not match its extension name.`,
         size: `${file.clientName} is too large. `,
         fatal: `The remote storage rejected the file: ${error.message}`,
       }

--- a/helpers/file_upload_helper.ts
+++ b/helpers/file_upload_helper.ts
@@ -7,7 +7,7 @@ export const allowedExtensions = ['zip', 'doc', 'docx', 'pdf']
 
 export const allowedPattern = new RegExp(`\\.(${allowedExtensions.join('|')})$`, 'i')
 
-export const maxFileSizeMB = app.inTest ? 50 : 500 // in "mb"
+export const maxFileSizeMB = app.inTest ? 150 : 500 // in "mb"
 
 export type FileMetadata = {
   keySalt: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@aws-sdk/s3-request-presigner": "^3.981.0",
         "@vinejs/vine": "^3.0.1",
         "adm-zip": "^0.5.16",
+        "file-type": "^21.3.0",
         "luxon": "^3.7.2",
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/s3-request-presigner": "^3.981.0",
     "@vinejs/vine": "^3.0.1",
     "adm-zip": "^0.5.16",
+    "file-type": "^21.3.0",
     "luxon": "^3.7.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2"

--- a/tests/functional/upload.spec.ts
+++ b/tests/functional/upload.spec.ts
@@ -145,12 +145,16 @@ test.group('Upload', (group) => {
       'file_path_not_provided',
       'file_not_found',
       'file_type_not_supported',
+      'file_type_spoofing',
       'file_size_exceeds_max_size',
     ] as const)
-    .run(async ({}, condition) => {
+    .run(async ({ assert }, condition) => {
       const email = 'test@example.com'
 
-      await User.create({ email, licence_key: cuid() })
+      const user = await User.create({ email, licence_key: cuid() })
+
+      await user.load('fileUploads')
+      assert.isEmpty(user.fileUploads)
 
       const title = 'My Important File'
 
@@ -163,12 +167,16 @@ test.group('Upload', (group) => {
       zipFile.addFile(
         'file.txt',
         condition === 'file_size_exceeds_max_size'
-          ? randomBytes(1024 * 1024 * (maxFileSizeMB + 10))
+          ? randomBytes(1024 * 1024 * (maxFileSizeMB + 5))
           : Buffer.alloc(1024, '0')
       )
 
-      if (condition !== 'file_not_found') {
+      if (condition !== 'file_not_found' && condition !== 'file_type_spoofing') {
         await zipFile.writeZipPromise(testFilePath)
+      }
+
+      if (condition === 'file_type_spoofing') {
+        fs.writeFileSync(testFilePath, 'Hello World')
       }
 
       const command = await ace.create(Upload, [
@@ -212,6 +220,10 @@ test.group('Upload', (group) => {
           message = `Invalid file type. Only ${allowedExtensions.join(', ')} are allowed.`
           break
 
+        case 'file_type_spoofing':
+          message = `The file content does not match its extension name.`
+          break
+
         case 'file_size_exceeds_max_size':
           message = `File size must not exceed ${maxFileSizeMB}mb.`
           break
@@ -229,6 +241,22 @@ test.group('Upload', (group) => {
       }
 
       command.assertLog(`[ red(error) ] ${message}`, 'stderr')
+
+      await user.load('fileUploads')
+
+      if (condition === 'file_type_spoofing') {
+        assert.lengthOf(user.fileUploads, 1)
+
+        // Assert that the initialised fileUpload remains pending, and no auth_tag or location is persisted (the file was not uploaded to remote storage)
+        assert.equal(user.fileUploads[0].status, FileUploadStatuses.Pending)
+
+        assert.exists(user.fileUploads[0].file_data)
+
+        assert.notExists(user.fileUploads[0].file_data.auth_tag)
+        assert.notExists(user.fileUploads[0].file_data.location)
+      } else {
+        assert.isEmpty(user.fileUploads)
+      }
     })
     .tags(['upload'])
     .timeout(30000)


### PR DESCRIPTION
This PR addresses this issue: https://github.com/debeemedia/vault-zip/issues/12. It:
- adds a PassThrough sniffer to verify the magic-bytes of the file (with [file-type package](https://www.npmjs.com/package/file-type)), effectively blocking extension name spoofing during file upload.
- adds a test to verify this.
- ensures that backpressure is correctly managed for large files.
- uses the `logger` where appropriate.