### PR TITLE
Return Upload and Download Action Links in Server Response

### DIFF
--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -1,6 +1,6 @@
 import env from '#start/env'
 import { cuid } from '@adonisjs/core/helpers'
-import { type HttpContext } from '@adonisjs/core/http'
+import type { HttpContext } from '@adonisjs/core/http'
 import { rules, schema } from '@adonisjs/validator'
 import { S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'

--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -1,6 +1,6 @@
 import env from '#start/env'
 import { cuid } from '@adonisjs/core/helpers'
-import type { HttpContext } from '@adonisjs/core/http'
+import { type HttpContext } from '@adonisjs/core/http'
 import { rules, schema } from '@adonisjs/validator'
 import { S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
@@ -19,6 +19,7 @@ import drive from '@adonisjs/drive/services/main'
 import { PassThrough } from 'node:stream'
 import { fileTypeFromStream } from 'file-type'
 import logger from '@adonisjs/core/services/logger'
+import router from '@adonisjs/core/services/router'
 
 const stringRules = [rules.trim(), rules.escape()]
 
@@ -50,6 +51,12 @@ export default class FileUploadsController {
         title: upload.title,
         original_file_name: upload.file_data.original_file_name,
         file_size: `${(upload.file_data.file_size / (1024 * 1024)).toFixed(2)} MB`,
+        links: {
+          download: {
+            method: 'GET',
+            href: router.makeUrl('file_uploads.show', [upload.id]),
+          },
+        },
       })) ?? []
 
     return response.ok({ data: fileUploads })
@@ -215,7 +222,15 @@ export default class FileUploadsController {
       },
     })
 
-    return response.created({ message: 'File upload initialised.', fileUploadId: fileUpload.id })
+    return response.created({
+      message: 'File upload initialised.',
+      links: {
+        upload: {
+          method: 'POST',
+          href: router.makeUrl('file_uploads.upload', [fileUpload.id]),
+        },
+      },
+    })
   }
 
   /**

--- a/commands/download.ts
+++ b/commands/download.ts
@@ -39,19 +39,24 @@ export default class Download extends BaseCommand {
 
     this.logger.info('Getting your files...')
 
-    const fileUploadsResponse = await fetch(
-      `http://${process.env.HOST}:${process.env.PORT}/file_uploads`,
-      {
-        method: 'GET',
-        headers: {
-          email: this.email,
-          licence_key: licenceKey,
-        },
-      }
-    )
+    const baseUrl = `http://${process.env.HOST}:${process.env.PORT}`
+
+    const fileUploadsResponse = await fetch(`${baseUrl}/file_uploads`, {
+      method: 'GET',
+      headers: {
+        email: this.email,
+        licence_key: licenceKey,
+      },
+    })
 
     const data = (await fileUploadsResponse.json()) as {
-      data?: { id: string; title: string; original_file_name: string; file_size: string }[]
+      data?: {
+        id: string
+        title: string
+        original_file_name: string
+        file_size: string
+        links?: { download: { method: string; href: string } }
+      }[]
       error?: string
       errors?: string[]
     }
@@ -95,10 +100,16 @@ export default class Download extends BaseCommand {
       }))
     )
 
+    const correspondingFileUpload = data.data.find((d) => d.id === fileUploadId)
+
+    if (!correspondingFileUpload?.links?.download) {
+      return
+    }
+
     const fileUploadResponse = await fetch(
-      `http://${process.env.HOST}:${process.env.PORT}/file_uploads/${fileUploadId}`,
+      `${baseUrl}${correspondingFileUpload.links.download.href}`,
       {
-        method: 'GET',
+        method: correspondingFileUpload.links.download.method,
         headers: {
           email: this.email,
           licence_key: licenceKey,

--- a/commands/upload.ts
+++ b/commands/upload.ts
@@ -52,9 +52,9 @@ export default class Upload extends BaseCommand {
     const formData = new FormData()
     formData.append('title', this.title)
 
-    const baseUrl = `http://${process.env.HOST}:${process.env.PORT}/file_uploads`
+    const baseUrl = `http://${process.env.HOST}:${process.env.PORT}`
 
-    const preFlightResponse = await fetch(baseUrl, {
+    const preFlightResponse = await fetch(`${baseUrl}/file_uploads`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -69,9 +69,14 @@ export default class Upload extends BaseCommand {
 
     const preFlightData = (await preFlightResponse.json()) as {
       message?: string
-      fileUploadId?: string
       error?: string
       errors?: string[]
+      links?: {
+        upload: {
+          method: string
+          href: string
+        }
+      }
     }
 
     if (!preFlightResponse.ok) {
@@ -80,7 +85,7 @@ export default class Upload extends BaseCommand {
       return (this.exitCode = 1)
     }
 
-    if (!preFlightData.fileUploadId) {
+    if (!preFlightData.links?.upload) {
       return
     }
 
@@ -91,8 +96,8 @@ export default class Upload extends BaseCommand {
 
     uploadData.append('file', fileBlob, fileName)
 
-    const response = await fetch(`${baseUrl}/${preFlightData.fileUploadId}`, {
-      method: 'POST',
+    const response = await fetch(`${baseUrl}${preFlightData.links.upload.href}`, {
+      method: preFlightData.links.upload.method,
       body: uploadData,
       headers: {
         email: this.email,

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -22,7 +22,9 @@ router
   .only(['store' /* Route to initialise the file upload */, 'index', 'show'])
 
 // Route to upload the file
-router.post('file_uploads/:file_upload_id', [
-  () => import('#controllers/file_uploads_controller'),
-  'upload',
-])
+router
+  .post('file_uploads/:file_upload_id', [
+    () => import('#controllers/file_uploads_controller'),
+    'upload',
+  ])
+  .as('file_uploads.upload')


### PR DESCRIPTION
This PR updates the backend responses to include a `links` object containing the necessary `method` and `href` for the next step, and updates the upload and download commands to use these links rather than hardcoding urls.