### PR TITLE
Implement App Key Versioning / Rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@ TZ=UTC
 PORT=3333
 HOST=localhost
 LOG_LEVEL=info
+# IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
 APP_KEY=
+APP_KEY_V1=
 NODE_ENV=development
 DB_HOST=127.0.0.1
 DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -155,6 +155,43 @@ Note: When testing with a hex editor, modify a byte toward the end of the file. 
 
 The command will fail and any corrupted output will be automatically deleted to protect your workspace.
 
+## 🔑 Encryption Key Lifecycle & Rotation
+
+Vault-Zip uses a Versioned Encryption System to ensure data remains accessible even as security requirements evolve. Instead of a single static key, the system manages a relationship between database records and environment-level secrets.
+
+### Key Features
+
+- Key Versioning: Every encrypted file and user licence key is tagged with an `encryption_key_version_id`, allowing the system to pick the correct decryption key automatically.
+
+- Zero-Downtime Rotation: Rotate to a new `APP_KEY` without immediately re-encrypting every file in your storage.
+
+- Environment Auditing: Built-in CLI tools to verify that required keys exist in your `.env` before attempting operations.
+
+### CLI Commands
+
+1. Audit Key Versions:
+   List all registered versions and check if they are active and if their corresponding environment variables are present.
+
+```bash
+docker compose exec app node ace vault-zip:list-key-versions
+```
+
+2. Rotate Active Key:
+   Safely transition the system to a new encryption key. This command performs pre-flight checks to ensure the new key is available in the environment before deactivating the old one.
+
+```bash
+docker compose exec app node ace vault-zip:rotate-active-key-version --version=2
+```
+
+If the provided version already exists in the database, it's `is_active` status is set to true, and the previous active key is deactivated. Only one key is active at a time for new encryptions.
+
+[!IMPORTANT] Key Syncing Requirement:
+
+When introducing a new key version (e.g., `APP_KEY_V2`) in your environment (`docker-compose.yml`), you must also update the base `APP_KEY` variable to match that same value.
+
+Why?
+The core framework and internal encryption providers use the `APP_KEY` variable by default for general purpose encryption. To ensure the system-wide encryption remains in sync with your latest rotated version, both variables must point to the same secret.
+
 ## 🧪 Testing & Reliability
 
 The suite provides 100% command coverage, ensuring the system is resilient against malformed data and malicious tampering.
@@ -166,8 +203,9 @@ docker compose run --rm tester
 ```
 
 - Comprehensive Command Coverage: Exhaustive integration tests for `register`, `upload`, `list`, `download`, and `decrypt`. Every command tested against database and cloud (S3/MinIO) storage drivers.
+  Exhaustive tests are also availabe for the `list-key-versions` and `rotate-active-key-version` commands.
 
-- Strict Validation: Covers all failure modes including missing/duplicate emails, title constraints, and file size/type violations.
+- Strict Validation: Covers all failure modes including missing/duplicate emails, title constraints, file size/type violations, and missing environment variables for the key versioning/rotation tests.
 
 - Large File Support: Verified handling of multi-megabyte streams near the maximum size limit.
 

--- a/app/controllers/file_uploads_controller.ts
+++ b/app/controllers/file_uploads_controller.ts
@@ -6,7 +6,6 @@ import { S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import FileUpload, { FileUploadStatuses } from '#models/file_upload'
 import User from '#models/user'
-import encryption from '@adonisjs/core/services/encryption'
 import crypto from 'node:crypto'
 import vine, { SimpleMessagesProvider } from '@vinejs/vine'
 import {
@@ -20,6 +19,8 @@ import { PassThrough } from 'node:stream'
 import { fileTypeFromStream } from 'file-type'
 import logger from '@adonisjs/core/services/logger'
 import router from '@adonisjs/core/services/router'
+import EncryptionKeyVersion from '#models/encryption_key_version'
+import EncryptionService from '#services/encryption_service'
 
 const stringRules = [rules.trim(), rules.escape()]
 
@@ -33,6 +34,12 @@ export default class FileUploadsController {
     const validationResult = await validateDownloadRequest(request)
 
     if (typeof validationResult === 'string') {
+      if (validationResult === User.DECRYPTION_ERROR_MESSAGE) {
+        return response.internalServerError({
+          error: 'There is a technical issue verifying your licence key. Please contact support.',
+        })
+      }
+
       return response.unprocessableEntity({ error: validationResult })
     }
 
@@ -88,7 +95,7 @@ export default class FileUploadsController {
 
     const encryptedStream = await drive.use('s3').getStream(location!)
 
-    const rawFileKey = this.#decryptFileKey(fileUpload)
+    const rawFileKey = await this.#decryptFileKey(fileUpload)
 
     /**
      * Generate a header metadata buffer to be bundled along with the encrypted file to the client
@@ -201,6 +208,18 @@ export default class FileUploadsController {
 
     const rawFileKey = crypto.randomBytes(32)
 
+    /**
+     * todo: Consider moving the encryption and decryption of the file key to model hooks, as is done for user licence key.
+     */
+
+    // On creation, use the active key version for encryption
+    const activeVersion = await EncryptionKeyVersion.query()
+      .select(['id', 'version'])
+      .where('is_active', true)
+      .firstOrFail()
+
+    const encryption = EncryptionService.getEncryption(activeVersion.version)
+
     const encryptedFileKey = encryption.encrypt(
       rawFileKey.toString('base64'),
       undefined,
@@ -210,6 +229,7 @@ export default class FileUploadsController {
     const iv = crypto.randomBytes(12)
 
     const fileUpload = await FileUpload.create({
+      encryption_key_version_id: activeVersion.id,
       title,
       user_id: user.id,
       status: FileUploadStatuses.Pending,
@@ -274,7 +294,10 @@ export default class FileUploadsController {
 
     const iv = Buffer.from(fileUpload.file_data.iv, 'base64')
 
-    const rawFileKey = this.#decryptFileKey(fileUpload)
+    /**
+     * todo: Consider moving the encryption and decryption of the file key to model hooks, as is done for user licence key.
+     */
+    const rawFileKey = await this.#decryptFileKey(fileUpload)
 
     request.multipart.onFile(
       'file',
@@ -411,13 +434,25 @@ export default class FileUploadsController {
 
   static #ENCRYPTION_PURPOSE = 'File Upload'
 
-  #decryptFileKey(fileUpload: FileUpload) {
+  async #decryptFileKey(fileUpload: FileUpload) {
+    // For decryption, use the key version that was used during encryption
+    const encryption = await FileUpload.getEncryption(fileUpload)
+
     const decryptedBase64FileKey = encryption.decrypt<string>(
       fileUpload.file_data.encrypted_file_key,
       FileUploadsController.#ENCRYPTION_PURPOSE
     )
 
     if (!decryptedBase64FileKey) {
+      await fileUpload.load('encryptionKeyVersion', (encryptionKeyVersionQuery) => {
+        encryptionKeyVersionQuery.select(['id', 'version'])
+      })
+
+      logger.error(
+        { fileUploadId: fileUpload.id, keyVersion: fileUpload.encryptionKeyVersion.version },
+        `[Decryption Failure] 'Unable to decrypt file key.`
+      )
+
       throw new Error('Unable to decrypt file key')
     }
 
@@ -456,11 +491,16 @@ async function validateDownloadRequest(request: HttpContext['request']) {
   })
 
   const user = await User.query()
-    .select(['id', 'licence_key'])
+    // IMPORTANT: Always select `encryption_key_version_id` when selecting `licence_key` so that the "afterFind" decryption hook can run properly.
+    .select(['id', 'licence_key', 'encryption_key_version_id'])
     .where({ email: validatedEmail })
     .first()
 
-  if (!user || user.licence_key !== validatedLicenceKey) {
+  if (user?.licence_key === User.DECRYPTION_ERROR_MESSAGE) {
+    return user.licence_key
+  }
+
+  if (user?.licence_key !== validatedLicenceKey) {
     return 'Provide your email with the corresponding licence key.'
   }
 

--- a/app/models/encryption_key_version.ts
+++ b/app/models/encryption_key_version.ts
@@ -1,0 +1,28 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
+import type { HasMany } from '@adonisjs/lucid/types/relations'
+import FileUpload from './file_upload.js'
+import User from './user.js'
+
+export default class EncryptionKeyVersion extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare version: string
+
+  @column()
+  declare is_active: boolean
+
+  @column.dateTime({ autoCreate: true })
+  declare created_at: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updated_at: DateTime
+
+  @hasMany(() => User, { foreignKey: 'encryption_key_version_id' })
+  declare users: HasMany<typeof User>
+
+  @hasMany(() => FileUpload, { foreignKey: 'encryption_key_version_id' })
+  declare fileUploads: HasMany<typeof FileUpload>
+}

--- a/app/models/file_upload.ts
+++ b/app/models/file_upload.ts
@@ -2,6 +2,8 @@ import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import User from './user.js'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import EncryptionKeyVersion from './encryption_key_version.js'
+import EncryptionService from '#services/encryption_service'
 
 type FileData = {
   original_file_name: string
@@ -28,6 +30,9 @@ export default class FileUpload extends BaseModel {
   @column()
   declare file_data: FileData
 
+  @column()
+  declare encryption_key_version_id: number
+
   @column.dateTime({ autoCreate: true })
   declare created_at: DateTime
 
@@ -36,6 +41,18 @@ export default class FileUpload extends BaseModel {
 
   @belongsTo(() => User, { foreignKey: 'user_id' })
   declare user: BelongsTo<typeof User>
+
+  @belongsTo(() => EncryptionKeyVersion, { foreignKey: 'encryption_key_version_id' })
+  declare encryptionKeyVersion: BelongsTo<typeof EncryptionKeyVersion>
+
+  public static async getEncryption(file_upload: FileUpload) {
+    const version = await EncryptionKeyVersion.query()
+      .select(['id', 'version'])
+      .where('id', file_upload.encryption_key_version_id)
+      .firstOrFail()
+
+    return EncryptionService.getEncryption(version.version)
+  }
 }
 
 export enum FileUploadStatuses {

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -1,11 +1,23 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
-import encryption from '@adonisjs/core/services/encryption'
-import type { HasMany } from '@adonisjs/lucid/types/relations'
+import {
+  afterFetch,
+  afterFind,
+  BaseModel,
+  beforeSave,
+  belongsTo,
+  column,
+  hasMany,
+} from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import FileUpload from './file_upload.js'
+import EncryptionService from '#services/encryption_service'
+import EncryptionKeyVersion from './encryption_key_version.js'
+import logger from '@adonisjs/core/services/logger'
 
 export default class User extends BaseModel {
   static ENCRYPTION_PURPOSE = 'Licensing'
+
+  static DECRYPTION_ERROR_MESSAGE = 'UNABLE_TO_DECRYPT'
 
   @column({ isPrimary: true })
   declare id: string
@@ -13,16 +25,110 @@ export default class User extends BaseModel {
   @column()
   declare email: string
 
-  @column({
-    columnName: 'licence_key',
-    prepare: (value: string) => encryption.encrypt(value, undefined, User.ENCRYPTION_PURPOSE),
-    consume: (value: string) => encryption.decrypt(value, User.ENCRYPTION_PURPOSE),
-  })
+  @column()
   declare licence_key: string
+
+  @column()
+  declare encryption_key_version_id: number
 
   @column.dateTime({ autoCreate: true })
   declare created_at: DateTime
 
   @hasMany(() => FileUpload, { foreignKey: 'user_id' })
   declare fileUploads: HasMany<typeof FileUpload>
+
+  @belongsTo(() => EncryptionKeyVersion, { foreignKey: 'encryption_key_version_id' })
+  declare encryptionKeyVersion: BelongsTo<typeof EncryptionKeyVersion>
+
+  public static async getEncryption(user: User) {
+    // Only run if we've selected an encryption_key_version_id to use.
+    if (!user.encryption_key_version_id) {
+      return null
+    }
+
+    const version = await EncryptionKeyVersion.query()
+      .select(['id', 'version'])
+      .where('id', user.encryption_key_version_id)
+      .firstOrFail()
+
+    return {
+      encryption: EncryptionService.getEncryption(version.version),
+      encryptionVersion: version.version,
+    }
+  }
+
+  // This hook runs before both creation and update.
+  @beforeSave()
+  public static async encryptLicenceKey(user: User) {
+    if (!user.encryption_key_version_id) {
+      // On creation, use the active key version for encryption
+      const activeVersion = await EncryptionKeyVersion.query()
+        .select(['id', 'version'])
+        .where('is_active', true)
+        .firstOrFail()
+
+      user.encryption_key_version_id = activeVersion.id
+    }
+
+    if (user.$dirty.licence_key) {
+      const encryptionResult = await this.getEncryption(user)
+
+      if (!encryptionResult) {
+        throw new Error(
+          `Failed to encrypt licence_key for ${user.email}: Encryption service unavailable for version ${user.encryption_key_version_id}`
+        )
+      }
+
+      user.licence_key = encryptionResult.encryption.encrypt(
+        user.licence_key,
+        undefined,
+        User.ENCRYPTION_PURPOSE
+      )
+    }
+  }
+
+  @afterFind()
+  public static async decryptSingleLicenceKey(user: User) {
+    // Only run if we've selected a licence_key to decrypt.
+    if (!user.licence_key) {
+      return
+    }
+
+    // For decryption, use the key version that was used during encryption
+    const encryptionResult = await this.getEncryption(user)
+
+    if (!encryptionResult) {
+      return
+    }
+
+    const { encryption, encryptionVersion } = encryptionResult
+
+    let licenceKey: string | null
+
+    licenceKey = encryption.decrypt(user.licence_key, User.ENCRYPTION_PURPOSE)
+
+    /**
+     * Decryption can return null if key used for encryption changes.
+     * Handle gracefully.
+     */
+    if (!licenceKey) {
+      logger.error(
+        { userId: user.id, keyVersion: encryptionVersion },
+        `[Decryption Failure] Unable to decrypt user's licence key.`
+      )
+
+      user.licence_key = User.DECRYPTION_ERROR_MESSAGE
+
+      return
+    }
+
+    user.licence_key = licenceKey
+  }
+
+  @afterFetch()
+  public static async decryptManyLicenceKeys(users: User[]) {
+    for (const user of users) {
+      await this.decryptSingleLicenceKey(user)
+    }
+  }
 }

--- a/app/services/encryption_service.ts
+++ b/app/services/encryption_service.ts
@@ -1,0 +1,16 @@
+import env from '#start/env'
+import { Encryption } from '@adonisjs/core/encryption'
+
+export default class EncryptionService {
+  public static getEncryption(version: string) {
+    const envKey = `APP_KEY_V${version}`
+
+    const secret = env.get(envKey)
+
+    if (!secret) {
+      throw new Error(`Missing environment variable: ${envKey}`)
+    }
+
+    return new Encryption({ algorithm: 'aes-256-cbc', secret })
+  }
+}

--- a/commands/list_key_versions.ts
+++ b/commands/list_key_versions.ts
@@ -1,0 +1,56 @@
+import EncryptionKeyVersion from '#models/encryption_key_version'
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+
+export default class ListKeyVersions extends BaseCommand {
+  static commandName = 'vault-zip:list-key-versions'
+  static description = 'View all encryption key versions, their status, and if present in env.'
+
+  static options: CommandOptions = {
+    startApp: true,
+    staysAlive: false,
+  }
+
+  async run() {
+    const versions = await EncryptionKeyVersion.query()
+      .select(['id', 'version', 'is_active', 'created_at', 'updated_at'])
+      // Active status should always come first
+      .orderByRaw('is_active DESC, version DESC')
+
+    if (!versions.length) {
+      this.logger.info('No key versions found in the database.')
+
+      return (this.exitCode = 0)
+    }
+
+    if (process?.stdout?.columns < 100) {
+      this.logger.warning('Terminal width is narrow. The table below might look messy.')
+    }
+
+    const table = this.ui.table()
+
+    table.head(['Version', 'Status', 'Present in Env?', 'Created At', 'Updated At'])
+
+    versions.forEach((version) => {
+      const envKey = `APP_KEY_V${version.version}`
+
+      const keyExists = !!process.env[envKey]
+
+      table.row([
+        version.version,
+
+        version.is_active ? this.colors.green('ACTIVE') : this.colors.gray('Inactive'),
+
+        keyExists ? 'Present' : this.colors.red('MISSING'),
+
+        version.created_at.toFormat('yyyy-MM-dd HH:mm'),
+
+        version.updated_at.toFormat('yyyy-MM-dd HH:mm'),
+      ])
+    })
+
+    this.logger.info('Encryption Key Versions:')
+
+    table.render()
+  }
+}

--- a/commands/rotate_active_key_version.ts
+++ b/commands/rotate_active_key_version.ts
@@ -1,0 +1,79 @@
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import db from '@adonisjs/lucid/services/db'
+
+export default class RotateActiveKeyVersion extends BaseCommand {
+  static commandName = 'vault-zip:rotate-active-key-version'
+  static description =
+    'Update active key version for encryption. If the provided version already exists, it will be made active.'
+
+  static options: CommandOptions = {
+    startApp: true,
+    staysAlive: false,
+  }
+
+  @flags.string()
+  declare version: string
+
+  async run() {
+    if (!this.version?.trim()) {
+      this.logger.error('Provide the version.')
+      return (this.exitCode = 1)
+    }
+
+    if (!/^[1-9]\d*$/.test(this.version)) {
+      this.logger.error('Version must be a positive whole number greather than zero.') // For now
+      return (this.exitCode = 1)
+    }
+
+    const envKey = `APP_KEY_V${this.version}`
+
+    if (!process.env[envKey]) {
+      this.logger.error(`Environment variable "${envKey}" is missing!`)
+      return (this.exitCode = 1)
+    }
+
+    const shouldRotate = await this.prompt.confirm(
+      'Are you sure you want to activate this key version? The current active version will be deactivated.'
+    )
+
+    if (shouldRotate) {
+      this.logger.info('Updating active key version...')
+    } else {
+      this.logger.info('Operation cancelled.')
+
+      return
+    }
+
+    try {
+      await db.transaction(async (trx) => {
+        await trx.rawQuery(`
+          UPDATE encryption_key_versions SET is_active = false WHERE is_active = true;
+          `)
+
+        const existingVersion = await trx
+          .from('encryption_key_versions')
+          .where('version', this.version)
+          .first()
+
+        const query = existingVersion
+          ? `
+          UPDATE encryption_key_versions
+          SET is_active = true, updated_at = NOW()
+          WHERE version = :version
+        `
+          : `
+        INSERT INTO encryption_key_versions (version, is_active, created_at, updated_at)
+        VALUES (:version, true, NOW(), NOW())
+        `
+
+        await trx.rawQuery(query, { version: this.version })
+      })
+
+      this.logger.success('Key version updated successfully')
+    } catch (error) {
+      this.logger.error(`Rotation failed: ${error.message}`)
+      this.exitCode = 1
+    }
+  }
+}

--- a/commands/rotate_active_key_version.ts
+++ b/commands/rotate_active_key_version.ts
@@ -22,7 +22,7 @@ export default class RotateActiveKeyVersion extends BaseCommand {
     }
 
     if (!/^[1-9]\d*$/.test(this.version)) {
-      this.logger.error('Version must be a positive whole number greather than zero.') // For now
+      this.logger.error('Version must be a positive whole number greater than zero.') // For now
       return (this.exitCode = 1)
     }
 
@@ -71,7 +71,7 @@ export default class RotateActiveKeyVersion extends BaseCommand {
         await trx.rawQuery(query, { version: this.version })
       })
 
-      this.logger.success('Key version updated successfully')
+      this.logger.success('Key version updated successfully.')
     } catch (error) {
       this.logger.error(`Rotation failed: ${error.message}`)
       this.exitCode = 1

--- a/commands/rotate_active_key_version.ts
+++ b/commands/rotate_active_key_version.ts
@@ -30,6 +30,7 @@ export default class RotateActiveKeyVersion extends BaseCommand {
 
     if (!process.env[envKey]) {
       this.logger.error(`Environment variable "${envKey}" is missing!`)
+
       return (this.exitCode = 1)
     }
 
@@ -42,7 +43,7 @@ export default class RotateActiveKeyVersion extends BaseCommand {
     } else {
       this.logger.info('Operation cancelled.')
 
-      return
+      return (this.exitCode = 0)
     }
 
     try {

--- a/database/migrations/1773682295223_create_encryption_key_versions_table.ts
+++ b/database/migrations/1773682295223_create_encryption_key_versions_table.ts
@@ -6,7 +6,7 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id')
-      table.string('version').index().notNullable()
+      table.string('version').index().notNullable().unique()
       table
         .boolean('is_active')
         .defaultTo('false')

--- a/database/migrations/1773682295223_create_encryption_key_versions_table.ts
+++ b/database/migrations/1773682295223_create_encryption_key_versions_table.ts
@@ -1,0 +1,31 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'encryption_key_versions'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('version').index().notNullable()
+      table
+        .boolean('is_active')
+        .defaultTo('false')
+        .notNullable()
+        .comment('Set to true when the version is in current use for new encryptions.')
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+
+    this.defer(async (trx) => {
+      await trx.rawQuery(`
+        INSERT INTO ${this.tableName} (version, is_active, created_at, updated_at)
+        VALUES ('1', true, NOW(), NOW())
+        `)
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1773682675119_create_add_encryption_key_version_column_to_users_and_file_uploads_table.ts
+++ b/database/migrations/1773682675119_create_add_encryption_key_version_column_to_users_and_file_uploads_table.ts
@@ -1,0 +1,46 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableNames = ['users', 'file_uploads']
+
+  async up() {
+    for (const tableName of this.tableNames) {
+      this.schema.alterTable(tableName, (table) => {
+        table.integer('encryption_key_version_id').nullable().index()
+
+        table
+          .foreign('encryption_key_version_id')
+          .references('id')
+          .inTable('encryption_key_versions')
+          .onUpdate('CASCADE')
+          .onDelete('RESTRICT')
+      })
+    }
+
+    this.defer(async (trx) => {
+      const v1 = await trx.from('encryption_key_versions').where('version', '1').firstOrFail()
+
+      for (const tableName of this.tableNames) {
+        await trx.rawQuery(`
+          UPDATE ${tableName} SET encryption_key_version_id = '${v1.id}' WHERE encryption_key_version_id IS NULL;
+          `)
+      }
+    })
+
+    this.defer(async (trx) => {
+      for (const tableName of this.tableNames) {
+        await trx.rawQuery(`
+          ALTER TABLE ${tableName} ALTER COLUMN encryption_key_version_id SET NOT NULL
+          `)
+      }
+    })
+  }
+
+  async down() {
+    for (const tableName of this.tableNames) {
+      this.schema.alterTable(tableName, (table) => {
+        table.dropColumn('encryption_key_version_id')
+      })
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,9 @@ services:
       - PORT=3333
       - HOST=0.0.0.0
       - LOG_LEVEL=info
+      # IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
       - APP_KEY=anystringanystringanystring
+      - APP_KEY_V1=anystringanystringanystring
       - NODE_ENV=development
       - DB_HOST=db
       - DB_PORT=5432
@@ -89,7 +91,9 @@ services:
       - TZ=UTC
       - HOST=0.0.0.0
       - LOG_LEVEL=info
+      # IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
       - APP_KEY=anystringanystringanystring
+      - APP_KEY_V1=anystringanystringanystring
       - NODE_ENV=test
       - DB_HOST=db_test
       - DB_PORT=5432

--- a/helpers/test_helper.ts
+++ b/helpers/test_helper.ts
@@ -1,6 +1,5 @@
 import FileUpload, { FileUploadStatuses } from '#models/file_upload'
 import AdmZip from 'adm-zip'
-import encryption from '@adonisjs/core/services/encryption'
 import crypto from 'crypto'
 import ConfigService from '#services/config_service'
 import { Readable } from 'stream'
@@ -11,6 +10,8 @@ import { PassThrough } from 'node:stream'
 import User from '#models/user'
 import drive from '@adonisjs/drive/services/main'
 import { generateMetadataBuffer } from './file_upload_helper.js'
+import EncryptionKeyVersion from '#models/encryption_key_version'
+import EncryptionService from '#services/encryption_service'
 
 export const targetUserFileTitlePrefix = 'Target User'
 export const anotherUserFileTitlePrefix = 'Another User'
@@ -42,6 +43,15 @@ export async function uploadFiles({
 
   const originalFileBuffers: Buffer[] = []
   const encryptedFileOutputPaths: string[] = []
+
+  // On creation of file upload, use the active key version for encryption
+  const activeVersion = await EncryptionKeyVersion.query()
+    // Ensure to select the `version`, for the model hooks
+    .select(['id', 'version'])
+    .where('is_active', true)
+    .firstOrFail()
+
+  const encryption = EncryptionService.getEncryption(activeVersion.version)
 
   for (let i = 0; i < 2; i++) {
     const zipFile = new AdmZip()
@@ -80,6 +90,7 @@ export async function uploadFiles({
     assert.isTrue(await disk.exists(fileNames[i]))
 
     const fileUpload = await FileUpload.create({
+      encryption_key_version_id: activeVersion.id,
       title: titles[i],
       status: FileUploadStatuses.Completed,
       user_id: user.id,

--- a/start/env.ts
+++ b/start/env.ts
@@ -15,6 +15,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   NODE_ENV: Env.schema.enum(['development', 'production', 'test'] as const),
   PORT: Env.schema.number(),
   APP_KEY: Env.schema.string(),
+  APP_KEY_V1: Env.schema.string(),
   HOST: Env.schema.string({ format: 'host' }),
   LOG_LEVEL: Env.schema.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']),
 

--- a/tests/functional/decrypt.spec.ts
+++ b/tests/functional/decrypt.spec.ts
@@ -36,7 +36,11 @@ test.group('Decrypt', (group) => {
         licence_key: cuid(),
       })
 
-      await ConfigService.saveLicenceKey(isLicenceKeyNotSavedLocally ? '' : user!.licence_key)
+      // Refresh to trigger the afterFind hook and get the decrypted licence key.
+      // Very important because apart from saving the decrypted key to the config, the `deriveAESKeyFromLicenceKey` function needs to run with the decrypted key.
+      await user.refresh()
+
+      await ConfigService.saveLicenceKey(isLicenceKeyNotSavedLocally ? '' : user.licence_key)
 
       // Upload some files for the user and download encrypted files locally
       const uploadResult = await uploadFiles({ assert, user, saveLocally: true })

--- a/tests/functional/download.spec.ts
+++ b/tests/functional/download.spec.ts
@@ -54,8 +54,15 @@ test.group('Download', (group) => {
 
       assert.lengthOf(users, 2)
 
+      users.map(async (u) => {
+        assert.exists(u.encryption_key_version_id)
+      })
+
       const user = users.find((u) => u.email === email)
       assert.exists(user)
+
+      // Refresh to trigger the afterFind hook and get the decrypted licence key
+      await user!.refresh()
 
       await ConfigService.saveLicenceKey(isLicenceKeyNotSavedLocally ? '' : user!.licence_key)
 

--- a/tests/functional/list_key_versions.spec.ts
+++ b/tests/functional/list_key_versions.spec.ts
@@ -1,0 +1,84 @@
+import { test } from '@japa/runner'
+import db from '@adonisjs/lucid/services/db'
+import ace from '@adonisjs/core/services/ace'
+import ListKeyVersions from '../../commands/list_key_versions.js'
+import EncryptionKeyVersion from '#models/encryption_key_version'
+
+test.group('List Key Versions', (group) => {
+  group.each.setup(async () => {
+    ace.ui.switchMode('raw')
+    await db.beginGlobalTransaction()
+
+    return async () => {
+      ace.ui.switchMode('normal')
+      await db.rollbackGlobalTransaction()
+    }
+  })
+
+  test('should list key versions: {$self}')
+    .with(['main_assertion', 'narrow_terminal_width', 'no_key_version_found'] as const)
+    .run(async ({ assert }, condition) => {
+      const isNarrowTerminalWidth = condition === 'narrow_terminal_width'
+      const isNoKeyVersionFound = condition === 'no_key_version_found'
+
+      if (process.stdout) {
+        process.stdout.columns = isNarrowTerminalWidth ? 80 : 120
+      }
+
+      const keyVersions = await EncryptionKeyVersion.query()
+      assert.lengthOf(keyVersions, 1)
+      assert.isTrue(keyVersions[0].is_active)
+
+      if (isNoKeyVersionFound) {
+        await keyVersions[0].delete()
+      } else {
+        // Let's create another inactive encryption key in the db, that is also missing in the env
+        await EncryptionKeyVersion.create({ version: '2', is_active: false })
+      }
+
+      const updatedKeyVersions = await EncryptionKeyVersion.query()
+
+      if (!isNoKeyVersionFound) {
+        assert.lengthOf(updatedKeyVersions, 2)
+      }
+
+      const command = await ace.create(ListKeyVersions, [])
+
+      await command.exec()
+
+      //  console.log(JSON.stringify(command.ui.logger.getLogs()))
+
+      command.assertSucceeded()
+
+      if (isNoKeyVersionFound) {
+        return command.assertLog('[ blue(info) ] No key versions found in the database.', 'stdout')
+      }
+
+      if (isNarrowTerminalWidth) {
+        command.assertLog(
+          '[ yellow(warn) ] Terminal width is narrow. The table below might look messy.',
+          'stdout'
+        )
+      }
+
+      command.assertLog('[ blue(info) ] Encryption Key Versions:', 'stdout')
+
+      const tableData = updatedKeyVersions.map((version) => [
+        version.version,
+
+        version.is_active ? command.colors.green('ACTIVE') : command.colors.gray('Inactive'),
+
+        version.id === keyVersions[0].id ? 'Present' : command.colors.red('MISSING'),
+
+        version.created_at.toFormat('yyyy-MM-dd HH:mm'),
+
+        version.updated_at.toFormat('yyyy-MM-dd HH:mm'),
+      ])
+
+      command.assertTableRows([
+        ['Version', 'Status', 'Present in Env?', 'Created At', 'Updated At'],
+        ...tableData,
+      ])
+    })
+    .tags(['key_versions', 'list_key_versions'])
+})

--- a/tests/functional/register.spec.ts
+++ b/tests/functional/register.spec.ts
@@ -7,6 +7,7 @@ import User from '#models/user'
 import app from '@adonisjs/core/services/app'
 import { relative } from 'path'
 import ConfigService from '#services/config_service'
+import EncryptionKeyVersion from '#models/encryption_key_version'
 
 test.group('Register', (group) => {
   group.each.setup(async () => {
@@ -58,6 +59,21 @@ test.group('Register', (group) => {
       )
 
       command.assertLog(`[ green(success) ] Registration successful.`, 'stdout')
+
+      const activeVersion = await EncryptionKeyVersion.query()
+        .where('is_active', true)
+        .firstOrFail()
+
+      // Assert the key version used for encrypting the licence key
+      assert.equal(user!.encryption_key_version_id, activeVersion.id)
+
+      await user!.load('encryptionKeyVersion')
+
+      assert.containSubset(user!.encryptionKeyVersion, {
+        id: activeVersion.id,
+        version: activeVersion.version,
+        is_active: activeVersion.is_active,
+      })
 
       // Assert that the licence key returned (decrypted) is different from what is stored (encrypted)
       const rawUser = await db.from('users').where({ email }).first()

--- a/tests/functional/rotate_active_key_version.spec.ts
+++ b/tests/functional/rotate_active_key_version.spec.ts
@@ -1,0 +1,161 @@
+import { test } from '@japa/runner'
+import db from '@adonisjs/lucid/services/db'
+import ace from '@adonisjs/core/services/ace'
+import EncryptionKeyVersion from '#models/encryption_key_version'
+import env from '#start/env'
+import RotateActiveKeyVersion from '../../commands/rotate_active_key_version.js'
+
+test.group('Rotate Active Key Version', (group) => {
+  const existingAppKey = process.env['APP_KEY']
+  const existingAppKeyV1 = process.env['APP_KEY_V1']
+  const newVersion = 20
+
+  group.each.setup(async () => {
+    ace.ui.switchMode('raw')
+    await db.beginGlobalTransaction()
+
+    return async () => {
+      // Reset the envs to previous state
+      delete process.env[`APP_KEY_V${newVersion}`]
+
+      if (existingAppKey) {
+        process.env['APP_KEY'] = existingAppKey
+      } else {
+        delete process.env['APP_KEY']
+      }
+
+      if (existingAppKeyV1) {
+        process.env['APP_KEY_V1'] = existingAppKeyV1
+      } else {
+        delete process.env['APP_KEY_V1']
+      }
+
+      ace.ui.switchMode('normal')
+      await db.rollbackGlobalTransaction()
+    }
+  })
+
+  test('should rotate active key version: {$self}')
+    .with([
+      'main_assertion',
+      'version_not_provided',
+      'version_not_valid',
+      'version_not_in_local_env',
+      'operation_cancelled',
+      'version_already_exists',
+    ] as const)
+    .run(async ({ assert }, condition) => {
+      if (condition === 'version_already_exists') {
+        await EncryptionKeyVersion.create({ version: String(newVersion), is_active: false })
+      }
+
+      const keyVersions = await EncryptionKeyVersion.query().orderBy('created_at', 'asc')
+
+      if (condition === 'version_already_exists') {
+        assert.lengthOf(keyVersions, 2)
+        assert.isTrue(keyVersions[0].is_active)
+        assert.isFalse(keyVersions[1].is_active)
+      } else {
+        assert.lengthOf(keyVersions, 1)
+        assert.isTrue(keyVersions[0].is_active)
+      }
+
+      const appKey = env.get('APP_KEY')
+      const appKeyV1 = env.get('APP_KEY_V1')
+      assert.exists(appKey)
+      assert.exists(appKeyV1)
+
+      const oldKeyValue = 'anystringanystringanystring-LTRSiAyokG-vlngl5WL'
+      process.env[`APP_KEY`] = oldKeyValue
+      process.env[`APP_KEY_V1`] = oldKeyValue
+      assert.equal(appKey, appKeyV1)
+
+      if (condition !== 'version_not_in_local_env') {
+        const newKeyValue = 'e1c4G0dLMXXy-LTRSiAyokG-vlngl5WL'
+
+        process.env[`APP_KEY_V${newVersion}`] = newKeyValue
+        process.env[`APP_KEY`] = newKeyValue
+      }
+
+      const command = await ace.create(RotateActiveKeyVersion, [
+        condition === 'version_not_provided'
+          ? ''
+          : `--version=${condition === 'version_not_valid' ? 0 : newVersion}`,
+      ])
+
+      // Trap the prompt before executing the command
+      if (
+        condition === 'main_assertion' ||
+        condition === 'operation_cancelled' ||
+        condition === 'version_already_exists'
+      ) {
+        command.prompt
+          .trap(
+            'Are you sure you want to activate this key version? The current active version will be deactivated.'
+          )
+          .replyWith(condition !== 'operation_cancelled')
+      }
+
+      await command.exec()
+
+      //  console.log(JSON.stringify(command.ui.logger.getLogs()))
+
+      if (condition === 'version_not_provided') {
+        command.assertLog('[ red(error) ] Provide the version.', 'stderr')
+      }
+      if (condition === 'version_not_valid') {
+        command.assertLog(
+          '[ red(error) ] Version must be a positive whole number greater than zero.',
+          'stderr'
+        )
+      }
+      if (condition === 'version_not_in_local_env') {
+        command.assertLog(
+          `[ red(error) ] Environment variable "APP_KEY_V${newVersion}" is missing!`,
+          'stderr'
+        )
+      }
+
+      if (
+        condition === 'main_assertion' ||
+        condition === 'operation_cancelled' ||
+        condition === 'version_already_exists'
+      ) {
+        command.assertSucceeded()
+      } else {
+        command.assertFailed()
+      }
+
+      if (condition === 'operation_cancelled') {
+        command.assertLog('[ blue(info) ] Operation cancelled.', 'stdout')
+      }
+
+      if (condition === 'main_assertion' || condition === 'version_already_exists') {
+        command.assertLog('[ blue(info) ] Updating active key version...', 'stdout')
+
+        command.assertLog('[ green(success) ] Key version updated successfully.', 'stdout')
+      }
+
+      // If the provided version already exists, the command succeeds and the version is set to active, while the previously active version is deactivated.
+
+      const updatedKeyVersions = await EncryptionKeyVersion.query()
+      assert.lengthOf(
+        updatedKeyVersions,
+        condition === 'main_assertion' || condition === 'version_already_exists' ? 2 : 1
+      )
+
+      if (condition !== 'main_assertion') {
+        return
+      }
+
+      const newActiveKeyVersion = updatedKeyVersions.find((version) => version.is_active)
+      assert.exists(newActiveKeyVersion)
+
+      assert.equal(newActiveKeyVersion!.version, newVersion)
+
+      assert.isFalse(
+        updatedKeyVersions.find((version) => version.id !== newActiveKeyVersion!.id)!.is_active
+      )
+    })
+    .tags(['key_versions', 'rotate_active_key_version'])
+})


### PR DESCRIPTION
This PR implements this issue: https://github.com/debeemedia/vault-zip/issues/16.

As expounded in the issue, every encrypted file and user licence key is tagged with an `encryption_key_version_id` during storage, allowing the system to pick the correct decryption key automatically during decryption.
A `list-key-versions` command is provisioned for viewing all key versions in the database and checking if they are active and if their corresponding environment variable is present locally.
A `rotate-active-key-version` is used to set a new active key version. Only one key is active at a time for new encryptions.
Comprehensive tests are made available for both commands and the docs is updated with requisite notes and instructions.