### PR TITLE
Implement Post-Boot Checks to Ensure Correct Master (APP) Key for Encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@ TZ=UTC
 PORT=3333
 HOST=localhost
 LOG_LEVEL=info
-# IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
+# IMPORTANT: `APP_KEY` must mirror the secret of the currently ACTIVE 
+# version in the `encryption_key_versions` table. 
+# Use `node ace vault-zip:list-key-versions` to confirm the active version.
 APP_KEY=
 APP_KEY_V1=
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ docker compose exec app node ace vault-zip:list-key-versions
 ```
 
 2. Rotate Active Key:
-   Safely transition the system to a new encryption key. This command performs pre-flight checks to ensure the new key is available in the environment before deactivating the old one.
+   Safely transition the system to a new encryption key. This command performs pre-flight checks to ensure the new key is available in the environment before deactivating the old one. In your `docker-compose.yml`, look under `services` -> `app` -> `environment`.
 
 ```bash
 docker compose exec app node ace vault-zip:rotate-active-key-version --version=2
@@ -187,10 +187,32 @@ If the provided version already exists in the database, it's `is_active` status 
 
 [!IMPORTANT] Key Syncing Requirement:
 
-When introducing a new key version (e.g., `APP_KEY_V2`) in your environment (`docker-compose.yml`), you must also update the base `APP_KEY` variable to match that same value.
+After running the command to rotate the key, ensure you update the `APP_KEY` to mirror the secret of the currently active version in the `encryption_key_versions` database table.
 
 Why?
 The core framework and internal encryption providers use the `APP_KEY` variable by default for general purpose encryption. To ensure the system-wide encryption remains in sync with your latest rotated version, both variables must point to the same secret.
+
+[!TIP]
+
+To generate a cryptographically secure key, run this command and copy the output from the terminal:
+
+```bash
+node ace generate:key --show
+```
+
+Sample Output: `HwQ8D8UKcK8c34sdcY3mXkO-pJ9yAnkR`
+
+## 🛡️ Data Integrity & The "Door Guard"
+
+To prevent "silent corruption" (encrypting data with an out-of-sync key), the system implements a strict Boot-Time Hash Validation:
+
+- Immutable Hashes: When a key version is first activated, a SHA-256 fingerprint of the secret is locked in the database.
+
+- Fail-Fast Protection: After application boot, the system hashes the current `APP_KEY` and compares it against the active database record.
+
+- Atomic Consistency: If the environment secret does not match the database "Source of Truth," the application will refuse to start, preventing accidental encryption with incorrect credentials.
+
+This system prioritizes data integrity over app functionality. Any mismatch in the master key used for encryption causes the app to crash after booting because, in this application, there is no other important feature that can be afforded runtime without resolving master key discrepancies.
 
 ## 🧪 Testing & Reliability
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Key Security Features:
 
 - Layered Security: Every file has a unique Data Key, which is itself encrypted by a Master Key. Even a database leak won't expose your files without the Master Key.
 
+- Cryptographic "Door Guard" & Key Rotation: Features a fail-safe boot-time integrity check that synchronizes environment secrets with an active key versioning system. This architecture enables zero-downtime master key rotation and ensures the application refuses to boot if the environment's `APP_KEY` does not match the active database version, preventing configuration drift and decryption failures.
+
 - Handshake Architecture: Utilizes a custom CLI for a secure two-step upload process. The backend validates file metadata (like size limits, extensions etc.) during the handshake phase to mitigate "blind upload" attacks, ensuring only compliant streams reach the encryption pipeline.
 
 ## 🔐 The Multi-Level Encryption Strategy
@@ -169,15 +171,17 @@ Vault-Zip uses a Versioned Encryption System to ensure data remains accessible e
 
 ### CLI Commands
 
-1. Audit Key Versions:
-   List all registered versions and check if they are active and if their corresponding environment variables are present.
+#### 1. List Key Versions:
+
+List all registered versions and check if they are active and if their corresponding environment variables are present.
 
 ```bash
 docker compose exec app node ace vault-zip:list-key-versions
 ```
 
-2. Rotate Active Key:
-   Safely transition the system to a new encryption key. This command performs pre-flight checks to ensure the new key is available in the environment before deactivating the old one. In your `docker-compose.yml`, look under `services` -> `app` -> `environment`.
+#### 2. Rotate Active Key:
+
+Safely transition the system to a new encryption key. This command performs pre-flight checks to ensure the new key is available in the environment before deactivating the old one. In your `docker-compose.yml`, look under `services` -> `app` -> `environment`.
 
 ```bash
 docker compose exec app node ace vault-zip:rotate-active-key-version --version=2

--- a/app/models/encryption_key_version.ts
+++ b/app/models/encryption_key_version.ts
@@ -14,6 +14,9 @@ export default class EncryptionKeyVersion extends BaseModel {
   @column()
   declare is_active: boolean
 
+  @column()
+  declare hash: string
+
   @column.dateTime({ autoCreate: true })
   declare created_at: DateTime
 

--- a/commands/rotate_active_key_version.ts
+++ b/commands/rotate_active_key_version.ts
@@ -1,6 +1,8 @@
 import { BaseCommand, flags } from '@adonisjs/core/ace'
 import type { CommandOptions } from '@adonisjs/core/types/ace'
 import db from '@adonisjs/lucid/services/db'
+import { hashKeySecret } from '../helpers/command_helper.js'
+import EncryptionKeyVersion from '#models/encryption_key_version'
 
 export default class RotateActiveKeyVersion extends BaseCommand {
   static commandName = 'vault-zip:rotate-active-key-version'
@@ -16,46 +18,87 @@ export default class RotateActiveKeyVersion extends BaseCommand {
   declare version: string
 
   async run() {
-    if (!this.version?.trim()) {
+    const providedVersion = this.version?.trim()
+    if (!providedVersion) {
       this.logger.error('Provide the version.')
       return (this.exitCode = 1)
     }
 
-    if (!/^[1-9]\d*$/.test(this.version)) {
+    if (!/^[1-9]\d*$/.test(providedVersion)) {
       this.logger.error('Version must be a positive whole number greater than zero.') // For now
       return (this.exitCode = 1)
     }
 
-    const envKey = `APP_KEY_V${this.version}`
+    const envKey = `APP_KEY_V${providedVersion}`
 
-    if (!process.env[envKey]) {
+    const secret = process.env[envKey]
+    if (!secret) {
       this.logger.error(`Environment variable "${envKey}" is missing!`)
 
       return (this.exitCode = 1)
     }
 
-    const shouldRotate = await this.prompt.confirm(
+    const existingVersion = await EncryptionKeyVersion.query()
+      .select(['id', 'hash'])
+      .where('version', providedVersion)
+      .first()
+
+    const hash = hashKeySecret(secret)
+
+    if (existingVersion && hash !== existingVersion.hash) {
+      this.logger.error(
+        `Security Alert: The secret for ${envKey} does not match the original hash stored in the database. Version secrets cannot be changed once established.`
+      )
+      return (this.exitCode = 1)
+    }
+
+    // Be absolutely sure of what you're doing
+    this.logger.warning('CRITICAL OPERATION: You are about to change the active encryption key.')
+
+    this.logger.info(`New Active Version: V${providedVersion}`)
+
+    this.logger.info(
+      `Required APP_KEY: ${secret.substring(0, 4)}...${secret.substring(secret.length - 4)}`
+    )
+
+    const confirm1 = await this.prompt.confirm(
       'Are you sure you want to activate this key version? The current active version will be deactivated.'
     )
 
-    if (shouldRotate) {
-      this.logger.info('Updating active key version...')
-    } else {
+    const cancelOperation = () => {
       this.logger.info('Operation cancelled.')
 
-      return (this.exitCode = 0)
+      this.exitCode = 0
     }
+
+    if (!confirm1) {
+      return cancelOperation()
+    }
+
+    const confirm2 = await this.prompt.confirm(
+      'WARNING: Once this command finishes, ALL subsequent CLI commands (including this one) will CRASH until you update your APP_KEY in the env. Proceed?'
+    )
+
+    if (!confirm2) {
+      return cancelOperation()
+    }
+
+    const typedVersion = await this.prompt.ask(
+      `Type the version number "${providedVersion}" to confirm the rotation.`
+    )
+    if (String(typedVersion)?.trim() !== String(providedVersion)) {
+      this.logger.error('Version mismatch. Rotation aborted.')
+
+      return (this.exitCode = 1)
+    }
+
+    this.logger.info('Updating active key version...')
 
     try {
       await db.transaction(async (trx) => {
         await trx.rawQuery(`
           UPDATE encryption_key_versions SET is_active = false WHERE is_active = true;
           `)
-
-        const existingVersion = await trx
-          .from('encryption_key_versions')
-          .where('version', this.version)
-          .first()
 
         const query = existingVersion
           ? `
@@ -64,14 +107,21 @@ export default class RotateActiveKeyVersion extends BaseCommand {
           WHERE version = :version
         `
           : `
-        INSERT INTO encryption_key_versions (version, is_active, created_at, updated_at)
-        VALUES (:version, true, NOW(), NOW())
+        INSERT INTO encryption_key_versions (version, is_active, hash, created_at, updated_at)
+        VALUES (:version, true, :hash, NOW(), NOW())
         `
 
-        await trx.rawQuery(query, { version: this.version })
+        await trx.rawQuery(query, { version: providedVersion, hash })
       })
 
-      this.logger.success('Key version updated successfully.')
+      this.logger.success(
+        `Rotation successful in DB. Ensure your env is updated: set APP_KEY to match ${envKey} to prevent subsequent boot failure.`
+      )
+
+      /**
+       * Note: Because this application works primarily with commands, if the APP_KEY is not updated to mirror the new active key, running any command will immediately trigger the check in the App Provider and cause a crash until the key is updated.
+       * In a normal app, this check would likely not kick in because the app is already running, except if the check is applied before every HTTP request (as in a middleware) or if the application is restarted after every successful rotation of the active key.
+       */
     } catch (error) {
       this.logger.error(`Rotation failed: ${error.message}`)
       this.exitCode = 1

--- a/database/migrations/1774953975583_add_hash_column_to_encryption_key_versions_table.ts
+++ b/database/migrations/1774953975583_add_hash_column_to_encryption_key_versions_table.ts
@@ -1,0 +1,41 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import { hashKeySecret } from '../../helpers/command_helper.js'
+
+export default class extends BaseSchema {
+  protected tableName = 'encryption_key_versions'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('hash').nullable() // string is enough for sha256 which outputs 64 characters.
+    })
+
+    this.defer(async (db) => {
+      const encryptionVersions = await db.from(this.tableName).select('id', 'version')
+
+      for (const encryptionVersion of encryptionVersions) {
+        const envKey = `APP_KEY_V${encryptionVersion.version}`
+        const secret = process.env[envKey]
+
+        if (!secret) {
+          throw new Error(
+            `Migration Failed: Missing ${envKey} in environment. Required to generate hashes.`
+          )
+        }
+
+        const hash = hashKeySecret(secret)
+
+        await db.from(this.tableName).where('id', encryptionVersion.id).update({ hash })
+      }
+
+      await db.schema.alterTable(this.tableName, (table) => {
+        table.string('hash').notNullable().alter()
+      })
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('hash')
+    })
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,9 @@ services:
       - PORT=3333
       - HOST=0.0.0.0
       - LOG_LEVEL=info
-      # IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
+      # IMPORTANT: `APP_KEY` must mirror the secret of the currently ACTIVE
+      # version in the `encryption_key_versions` table.
+      # Use `node ace vault-zip:list-key-versions` to confirm the active version.
       - APP_KEY=anystringanystringanystring
       - APP_KEY_V1=anystringanystringanystring
       - NODE_ENV=development
@@ -91,7 +93,9 @@ services:
       - TZ=UTC
       - HOST=0.0.0.0
       - LOG_LEVEL=info
-      # IMPORTANT: `APP_KEY` must always be same as the highest version in `APP_KEY_V{n}
+      # IMPORTANT: `APP_KEY` must mirror the secret of the currently ACTIVE
+      # version in the `encryption_key_versions` table.
+      # Use `node ace vault-zip:list-key-versions` to confirm the active version.
       - APP_KEY=anystringanystringanystring
       - APP_KEY_V1=anystringanystringanystring
       - NODE_ENV=test

--- a/helpers/command_helper.ts
+++ b/helpers/command_helper.ts
@@ -1,5 +1,6 @@
 import ConfigService from '#services/config_service'
 import { BaseCommand } from '@adonisjs/core/ace'
+import crypto from 'node:crypto'
 
 export async function resolveLicenceKey({
   overrideKey,
@@ -31,4 +32,8 @@ export async function resolveLicenceKey({
   }
 
   return licenceKey
+}
+
+export function hashKeySecret(secret: string) {
+  return crypto.createHash('sha256').update(secret).digest('hex')
 }

--- a/providers/app_provider.ts
+++ b/providers/app_provider.ts
@@ -1,5 +1,6 @@
 import type { ApplicationService } from '@adonisjs/core/types'
 import { BaseModel, SnakeCaseNamingStrategy } from '@adonisjs/lucid/orm'
+import { hashKeySecret } from '../helpers/command_helper.js'
 
 export default class AppProvider {
   constructor(protected app: ApplicationService) {}
@@ -21,7 +22,40 @@ export default class AppProvider {
   /**
    * The application has been booted
    */
-  async start() {}
+  async start() {
+    /**
+     * Ensure that the APP_KEY used for encryptions matches the active version in the database, to prevent failure during decryption.
+     *
+     * Note: This check is placed here in the `start` rather than the `boot` lifecycle method because the db connection is already resolved and ready here.
+     */
+    const db = (await import('@adonisjs/lucid/services/db')).default
+
+    const tableName = 'encryption_key_versions'
+
+    if (
+      (await db.connection().schema.hasTable(tableName)) &&
+      (await db.from(tableName).select('id').first()) &&
+      (await db.connection().schema.hasColumn(tableName, 'hash'))
+    ) {
+      // If the table is empty, we assume it's a fresh install/migration phase.
+      // We only throw if there is data, but none is active, or if the hash is wrong.
+      const activeKey = await db
+        .from(tableName)
+        .select(['id', 'hash', 'version'])
+        .where({ is_active: true })
+        .first()
+
+      if (!activeKey) {
+        throw new Error(`[CRITICAL SECURITY ERROR]: No active encryption key found in database.`)
+      }
+
+      if (hashKeySecret(process.env.APP_KEY || '') !== activeKey.hash) {
+        throw new Error(
+          `[CRITICAL SECURITY ERROR]: The APP_KEY in your environment does not match the active database version "${activeKey.version}"`
+        )
+      }
+    }
+  }
 
   /**
    * The process has been started

--- a/tests/functional/list_key_versions.spec.ts
+++ b/tests/functional/list_key_versions.spec.ts
@@ -3,6 +3,7 @@ import db from '@adonisjs/lucid/services/db'
 import ace from '@adonisjs/core/services/ace'
 import ListKeyVersions from '../../commands/list_key_versions.js'
 import EncryptionKeyVersion from '#models/encryption_key_version'
+import { hashKeySecret } from '../../helpers/command_helper.js'
 
 test.group('List Key Versions', (group) => {
   group.each.setup(async () => {
@@ -33,7 +34,11 @@ test.group('List Key Versions', (group) => {
         await keyVersions[0].delete()
       } else {
         // Let's create another inactive encryption key in the db, that is also missing in the env
-        await EncryptionKeyVersion.create({ version: '2', is_active: false })
+        await EncryptionKeyVersion.create({
+          version: '2',
+          is_active: false,
+          hash: hashKeySecret('secret'),
+        })
       }
 
       const updatedKeyVersions = await EncryptionKeyVersion.query()

--- a/tests/functional/register.spec.ts
+++ b/tests/functional/register.spec.ts
@@ -75,6 +75,8 @@ test.group('Register', (group) => {
         is_active: activeVersion.is_active,
       })
 
+      assert.exists(user!.encryptionKeyVersion.hash)
+
       // Assert that the licence key returned (decrypted) is different from what is stored (encrypted)
       const rawUser = await db.from('users').where({ email }).first()
 

--- a/tests/functional/rotate_active_key_version.spec.ts
+++ b/tests/functional/rotate_active_key_version.spec.ts
@@ -4,6 +4,7 @@ import ace from '@adonisjs/core/services/ace'
 import EncryptionKeyVersion from '#models/encryption_key_version'
 import env from '#start/env'
 import RotateActiveKeyVersion from '../../commands/rotate_active_key_version.js'
+import { hashKeySecret } from '../../helpers/command_helper.js'
 
 test.group('Rotate Active Key Version', (group) => {
   const existingAppKey = process.env['APP_KEY']
@@ -43,15 +44,31 @@ test.group('Rotate Active Key Version', (group) => {
       'version_not_in_local_env',
       'operation_cancelled',
       'version_already_exists',
+      'version_exists_but_secret_changed',
+      'confirmation_version_mismatch',
     ] as const)
     .run(async ({ assert }, condition) => {
-      if (condition === 'version_already_exists') {
-        await EncryptionKeyVersion.create({ version: String(newVersion), is_active: false })
+      const newKeyValue = 'e1c4G0dLMXXy-LTRSiAyokG-vlngl5WL'
+
+      if (
+        condition === 'version_already_exists' ||
+        condition === 'version_exists_but_secret_changed'
+      ) {
+        await EncryptionKeyVersion.create({
+          version: String(newVersion),
+          is_active: false,
+          hash: hashKeySecret(
+            condition === 'version_exists_but_secret_changed' ? 'secret' : newKeyValue
+          ),
+        })
       }
 
       const keyVersions = await EncryptionKeyVersion.query().orderBy('created_at', 'asc')
 
-      if (condition === 'version_already_exists') {
+      if (
+        condition === 'version_already_exists' ||
+        condition === 'version_exists_but_secret_changed'
+      ) {
         assert.lengthOf(keyVersions, 2)
         assert.isTrue(keyVersions[0].is_active)
         assert.isFalse(keyVersions[1].is_active)
@@ -71,8 +88,6 @@ test.group('Rotate Active Key Version', (group) => {
       assert.equal(appKey, appKeyV1)
 
       if (condition !== 'version_not_in_local_env') {
-        const newKeyValue = 'e1c4G0dLMXXy-LTRSiAyokG-vlngl5WL'
-
         process.env[`APP_KEY_V${newVersion}`] = newKeyValue
         process.env[`APP_KEY`] = newKeyValue
       }
@@ -87,13 +102,26 @@ test.group('Rotate Active Key Version', (group) => {
       if (
         condition === 'main_assertion' ||
         condition === 'operation_cancelled' ||
-        condition === 'version_already_exists'
+        condition === 'version_already_exists' ||
+        condition === 'confirmation_version_mismatch'
       ) {
         command.prompt
           .trap(
             'Are you sure you want to activate this key version? The current active version will be deactivated.'
           )
+          .replyWith(true)
+
+        command.prompt
+          .trap(
+            'WARNING: Once this command finishes, ALL subsequent CLI commands (including this one) will CRASH until you update your APP_KEY in the env. Proceed?'
+          )
           .replyWith(condition !== 'operation_cancelled')
+
+        if (condition !== 'operation_cancelled') {
+          command.prompt
+            .trap(`Type the version number "${newVersion}" to confirm the rotation.`)
+            .replyWith(condition === 'confirmation_version_mismatch' ? '500' : newVersion)
+        }
       }
 
       await command.exec()
@@ -115,6 +143,15 @@ test.group('Rotate Active Key Version', (group) => {
           'stderr'
         )
       }
+      if (condition === 'version_exists_but_secret_changed') {
+        command.assertLog(
+          `[ red(error) ] Security Alert: The secret for APP_KEY_V${newVersion} does not match the original hash stored in the database. Version secrets cannot be changed once established.`,
+          'stderr'
+        )
+      }
+      if (condition === 'confirmation_version_mismatch') {
+        command.assertLog(`[ red(error) ] Version mismatch. Rotation aborted.`, 'stderr')
+      }
 
       if (
         condition === 'main_assertion' ||
@@ -131,9 +168,24 @@ test.group('Rotate Active Key Version', (group) => {
       }
 
       if (condition === 'main_assertion' || condition === 'version_already_exists') {
+        command.assertLog(
+          '[ yellow(warn) ] CRITICAL OPERATION: You are about to change the active encryption key.',
+          'stdout'
+        )
+
+        command.assertLog(`[ blue(info) ] New Active Version: V${newVersion}`, 'stdout')
+
+        command.assertLog(
+          `[ blue(info) ] Required APP_KEY: ${newKeyValue.substring(0, 4)}...${newKeyValue.substring(newKeyValue.length - 4)}`,
+          'stdout'
+        )
+
         command.assertLog('[ blue(info) ] Updating active key version...', 'stdout')
 
-        command.assertLog('[ green(success) ] Key version updated successfully.', 'stdout')
+        command.assertLog(
+          `[ green(success) ] Rotation successful in DB. Ensure your env is updated: set APP_KEY to match APP_KEY_V${newVersion} to prevent subsequent boot failure.`,
+          'stdout'
+        )
       }
 
       // If the provided version already exists, the command succeeds and the version is set to active, while the previously active version is deactivated.
@@ -141,7 +193,11 @@ test.group('Rotate Active Key Version', (group) => {
       const updatedKeyVersions = await EncryptionKeyVersion.query()
       assert.lengthOf(
         updatedKeyVersions,
-        condition === 'main_assertion' || condition === 'version_already_exists' ? 2 : 1
+        condition === 'main_assertion' ||
+          condition === 'version_already_exists' ||
+          condition === 'version_exists_but_secret_changed'
+          ? 2
+          : 1
       )
 
       if (condition !== 'main_assertion') {


### PR DESCRIPTION
This PR implements this issue: https://github.com/debeemedia/vault-zip/issues/19

The PR implements a comprehensive secure "door guard" strategy for ensuring the APP KEY mirrors the currently active key  version for encryption
- adds `hash` column to the `encryption_key_versions` table for storing the hash of the key secret
- improves the `rotate-active-key-version` command with more checks and warning logs, and persists the hash of the secret of the provided version
- improves the test with more cases and assertions
-  in the `app_provider`, after the app has booted, checks that the hash of the APP_KEY variable in the env matches the hash of the active key version in the database; if no match, throws an error to crash the app (in this application, there is no other important feature that we can afford to allow to run without resolving master key discrepancies)
- updates the README